### PR TITLE
feat(populate): Add populate operator to rxjs-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.0",
 			"license": "MIT",
 			"dependencies": {
+				"lodash": "4.17.21",
 				"obj-clean": "3.0.1",
 				"ramda": "0.29.0",
 				"rxjs": "7.8.1"
@@ -19,6 +20,7 @@
 				"@nx/linter": "16.6.0",
 				"@nx/vite": "16.6.0",
 				"@nx/workspace": "16.6.0",
+				"@types/lodash": "4.14.202",
 				"@types/node": "18.7.1",
 				"@types/ramda": "0.29.3",
 				"@typescript-eslint/eslint-plugin": "^5.60.1",
@@ -3452,6 +3454,12 @@
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+			"dev": true
+		},
+		"node_modules/@types/lodash": {
+			"version": "4.14.202",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+			"integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -6988,8 +6996,7 @@
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"node_modules/lodash.debounce": {
 			"version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	},
 	"private": true,
 	"dependencies": {
+		"lodash": "4.17.21",
 		"obj-clean": "3.0.1",
 		"ramda": "0.29.0",
 		"rxjs": "7.8.1"
@@ -24,6 +25,7 @@
 		"@nx/linter": "16.6.0",
 		"@nx/vite": "16.6.0",
 		"@nx/workspace": "16.6.0",
+		"@types/lodash": "4.14.202",
 		"@types/node": "18.7.1",
 		"@types/ramda": "0.29.3",
 		"@typescript-eslint/eslint-plugin": "^5.60.1",

--- a/packages/rxjs-utils/docs/operators/populate/populate.operator.md
+++ b/packages/rxjs-utils/docs/operators/populate/populate.operator.md
@@ -1,0 +1,22 @@
+# populate
+
+Populates the missing values within data provided by observables provided in a key-based record. 
+
+It expects a record of Observables that match with the keys of the object. An optional matching function can be presented to define when data should be populated
+
+## How to use
+
+```typescript
+import { populate } from "@studiohyperdrive/rxjs-utils";
+import { of } from "rxjs";
+
+of({hello: 'world'}).pipe(
+  populate({
+    world: () => of('hello'),
+    'foo.bar': (data) => of(data.hello)
+  })
+)
+  .subscribe((result) => {
+    // => result: {hello: 'world', world: 'hello', foo: {bar: 'world'}}
+  });
+```

--- a/packages/rxjs-utils/package.json
+++ b/packages/rxjs-utils/package.json
@@ -1,15 +1,17 @@
 {
 	"name": "@studiohyperdrive/rxjs-utils",
-	"version": "1.1.0",
+	"version": "2.0.0",
 	"license": "MIT",
 	"main": "./index.js",
 	"module": "./index.mjs",
 	"typings": "./index.d.ts",
 	"peerDependencies": {
 		"ramda": "^0.29.0",
+    "lodash":"4.17.21",
 		"rxjs": "^7.8.1",
 		"vite": "~4.3.9",
 		"vite-plugin-dts": "~2.3.0",
-		"@nx/vite": "16.6.0"
+		"@nx/vite": "16.6.0",
+    "vite-plugin-static-copy": "0.17.0"
 	}
 }

--- a/packages/rxjs-utils/src/lib/operators/index.ts
+++ b/packages/rxjs-utils/src/lib/operators/index.ts
@@ -3,3 +3,4 @@ export * from './pluck-or/pluck-or.operator';
 export * from './combine-boolean/combine-boolean.operator';
 export * from './pluck/pluck.operator';
 export * from './validate-content/validate-content.operator';
+export * from './populate/populate.operator';

--- a/packages/rxjs-utils/src/lib/operators/populate/populate.operator.md
+++ b/packages/rxjs-utils/src/lib/operators/populate/populate.operator.md
@@ -1,0 +1,22 @@
+# populate
+
+Populates the missing values within data provided by observables provided in a key-based record. 
+
+It expects a record of Observables that match with the keys of the object. An optional matching function can be presented to define when data should be populated
+
+## How to use
+
+```typescript
+import { populate } from "@studiohyperdrive/rxjs-utils";
+import { of } from "rxjs";
+
+of({hello: 'world'}).pipe(
+  populate({
+    world: () => of('hello'),
+    'foo.bar': (data) => of(data.hello)
+  })
+)
+  .subscribe((result) => {
+    // => result: {hello: 'world', world: 'hello', foo: {bar: 'world'}}
+  });
+```

--- a/packages/rxjs-utils/src/lib/operators/populate/populate.operator.spec.ts
+++ b/packages/rxjs-utils/src/lib/operators/populate/populate.operator.spec.ts
@@ -1,0 +1,59 @@
+import { of } from 'rxjs';
+import { isString } from 'lodash';
+import { populate } from './populate.operator';
+
+describe('populate', () => {
+	describe('Default populateIf', () => {
+		const page = of({
+			title: 'Test',
+			description: 'Test',
+			ads: {
+				adsId: '1',
+			},
+			linkId: '1',
+		});
+
+		const populateRecord = {
+			'ads.items': (data: any) => of([data.ads.adsId]),
+			link: () => of({ url: 'youtube.com/@Iben' }),
+		};
+		it('should correctly populate the missing keys', async () => {
+			page.pipe(populate(populateRecord)).subscribe((result) => {
+				expect(result).toEqual({
+					title: 'Test',
+					description: 'Test',
+					link: { url: 'youtube.com/@Iben' },
+					linkId: '1',
+					ads: {
+						adsId: '1',
+						items: ['1'],
+					},
+				});
+			});
+		});
+	});
+
+	describe('Default populateIf', () => {
+		const page = of({
+			title: 'Test',
+			description: 'Test',
+			ads: '1',
+			link: '1',
+		});
+		const populateRecord = {
+			ads: (data: any) => of([data.ads]),
+			link: () => of({ url: 'youtube.com/@Iben' }),
+		};
+
+		it('should correctly populate the missing keys', async () => {
+			page.pipe(populate(populateRecord, (value) => isString(value))).subscribe((result) => {
+				expect(result).toEqual({
+					title: 'Test',
+					description: 'Test',
+					link: { url: 'youtube.com/@Iben' },
+					ads: ['1'],
+				});
+			});
+		});
+	});
+});

--- a/packages/rxjs-utils/src/lib/operators/populate/populate.operator.ts
+++ b/packages/rxjs-utils/src/lib/operators/populate/populate.operator.ts
@@ -1,0 +1,43 @@
+import { Observable, OperatorFunction, combineLatest, map, switchMap } from 'rxjs';
+import { get, set } from 'lodash';
+
+//TODO: Iben: Find out a way to type this better than with any, but without introducing a complex typing hell
+/**
+ * Populates an existing data source with additional data from provided observables
+ *
+ * @param  populater - A record of which keys need to be updated with a provided observable
+ * @param populateIf - An optional function to determine when a value needs to be fetched
+ */
+export const populate = <DataType extends object>(
+	populater: Record<string, (data: DataType) => Observable<any>>,
+	populateIf?: (value: any) => boolean
+): OperatorFunction<DataType, DataType> => {
+	return switchMap((data) => {
+		// Iben: Filter out all keys that are populated
+		const keys = Object.keys(populater).filter((key) => {
+			const value = get(data, key);
+
+			// Iben: If no populateIf function is provided, we check if the value is undefined or null
+			if (!populateIf) {
+				return value === undefined || value === null;
+			}
+
+			// Iben: If a populateIf function is provided, we use this function to see whether we should populate a key
+			return populateIf(value);
+		});
+
+		// Iben: Loop over each value and
+		return combineLatest([...keys].map((key) => populater[key](data))).pipe(
+			map((results) => {
+				const result = { ...data };
+
+				// Iben: Loop over the results and merge them into the value
+				results.forEach((value, index) => {
+					set(result, keys[index], value);
+				});
+
+				return result;
+			})
+		);
+	});
+};


### PR DESCRIPTION
Voegt een operator toe om automatisch properties in data te gaan opvullen met resultaten van andere observables.

Op termijn moet gekeken worden voor twee zaken:

1.  Nagaan of we de typing beter kunnen doen
2. Zien of we ofwel lodash ofwel ramda kunnen vervangen door de een of de andere (voorrang gaat naar lodash, gezien de set functie niet geheel overeenkomt in ramda)