### PR TITLE
fix(rxjs-utils) Fix issue with populate when there are no items to populate

### DIFF
--- a/packages/rxjs-utils/package.json
+++ b/packages/rxjs-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@studiohyperdrive/rxjs-utils",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"license": "MIT",
 	"main": "./index.js",
 	"module": "./index.mjs",

--- a/packages/rxjs-utils/src/lib/operators/populate/populate.operator.spec.ts
+++ b/packages/rxjs-utils/src/lib/operators/populate/populate.operator.spec.ts
@@ -43,15 +43,44 @@ describe('populate', () => {
 		const populateRecord = {
 			ads: (data: any) => of([data.ads]),
 			link: () => of({ url: 'youtube.com/@Iben' }),
+			'hello.world': () => {
+				return of('');
+			},
 		};
 
 		it('should correctly populate the missing keys', async () => {
-			page.pipe(populate(populateRecord, (value) => isString(value))).subscribe((result) => {
+			page.pipe(populate(populateRecord, (value) => typeof value === 'string')).subscribe((result) => {
 				expect(result).toEqual({
 					title: 'Test',
 					description: 'Test',
 					link: { url: 'youtube.com/@Iben' },
 					ads: ['1'],
+				});
+			});
+		});
+	});
+
+	describe('Default populateIf', () => {
+		const page = of({
+			title: 'Test',
+			description: 'Test',
+			ads: '1',
+			link: '1',
+		});
+		const populateRecord = {
+			'hello.world': () => {
+				console.log('I AM RUNNING');
+				return of('');
+			},
+		};
+
+		it('should correctly populate the missing keys', async () => {
+			page.pipe(populate(populateRecord, (value) => typeof value === 'string')).subscribe((result) => {
+				expect(result).toEqual({
+					title: 'Test',
+					description: 'Test',
+					link: '1',
+					ads: '1',
 				});
 			});
 		});

--- a/packages/rxjs-utils/src/lib/operators/populate/populate.operator.ts
+++ b/packages/rxjs-utils/src/lib/operators/populate/populate.operator.ts
@@ -1,4 +1,4 @@
-import { Observable, OperatorFunction, combineLatest, map, switchMap } from 'rxjs';
+import { Observable, OperatorFunction, combineLatest, map, of, switchMap } from 'rxjs';
 import { cloneDeep, get, set } from 'lodash';
 
 //TODO: Iben: Find out a way to type this better than with any, but without introducing a complex typing hell
@@ -26,8 +26,16 @@ export const populate = <DataType extends object>(
 			return populateIf(value);
 		});
 
-		// Iben: Loop over each value and
-		return combineLatest([...keys].map((key) => populater[key](data))).pipe(
+		// Iben: Map the keys to their corresponding observables
+		const observables = [...keys].map((key) => populater[key](data));
+
+		// Iben: If no Observables were generated, return the data as is
+		if (observables.length === 0) {
+			return of(data);
+		}
+
+		// Iben: Loop over the provided observables and populate the data
+		return combineLatest(observables).pipe(
 			map((results) => {
 				// Iben: Use cloneDeep to avoid issues with readonly properties
 				const result = cloneDeep(data) as DataType;


### PR DESCRIPTION
When no properties matched with the populate record, the combineLatest received an empty array, which resulted in it never completing. 

This fix returns the data when the list of populate observables is empty.